### PR TITLE
fix op.config by add required moniker_ranges

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -6,7 +6,7 @@
       "build_output_subfolder": "office-ui-fabric-react",
       "locale": "en-us",
       "monikers": [],
-      "moniker_ranges": [],
+      "moniker_ranges": [ "office-ui-fabric-react-latest" ],
       "open_to_public_contributors": true,
       "type_mapping": {
         "Conceptual": "Content",


### PR DESCRIPTION
This is a dependency to make `moniker_range` in `docfx.json` work: https://github.com/MicrosoftDocs/oufr-dev-docs/blob/live/office-ui-fabric-react/docfx.json#L62