### PR TITLE
update build_source_folder to fix the open publishing build

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -2,7 +2,7 @@
   "docsets_to_publish": [
     {
       "docset_name": "office-ui-fabric-react",
-      "build_source_folder": "office-ui-fabric-react",
+      "build_source_folder": "static-doc-data",
       "build_output_subfolder": "office-ui-fabric-react",
       "locale": "en-us",
       "monikers": [],


### PR DESCRIPTION
The source repo(https://github.com/OfficeDev/office-ui-fabric-react) is not onboarding to OPS, I think this pull request is needed for this repository

