### PR TITLE
Fix broken link

### DIFF
--- a/office-ui-fabric-react/api/react-internal/itextfieldprops.yml
+++ b/office-ui-fabric-react/api/react-internal/itextfieldprops.yml
@@ -43,8 +43,8 @@ properties:
       Whether the input field should have autocomplete enabled. This tells the
       browser to display options based on earlier typed values. Common values
       are 'on' and 'off' but for all possible values see the following links:
-      https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete\#Values
-      https://html.spec.whatwg.org/multipage/form-control-infrastructure.html\#autofill
+      https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete#Values
+      https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill
     remarks: ''
     isPreview: false
     isDeprecated: false


### PR DESCRIPTION
The links in the documentation points to a page that doesn't exist due to an escape character. Removed `\` character to point to the correct resource.

⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️
⚠️⚠️⚠️⚠️WARNING ⚠️⚠️⚠️⚠️
⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️

This repo is AUTO UPDATED by a scheduled task so submitting pull requests here will make NO DIFFERENCE 😊 to the docs content.

PLEASE CONSIDER to submit either an issue or a PR with the fix intended in the source repository this documentation is based on. You can find it here: https://github.com/OfficeDev/office-ui-fabric-react

THANKS 👍

⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️
⚠️⚠️⚠️⚠️WARNING ⚠️⚠️⚠️⚠️
⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️
